### PR TITLE
Make import dba csv handle big files

### DIFF
--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -667,7 +667,7 @@ function Import-DbaCsv {
 
                             #if we're truncating and wrapped in a transaction, otherwise provide potentially unsafe sql as output to be used by caller with discretion
                             $UpdateStatementForStaticColumns = "UPDATE [$schema].[$table] SET $($sqlColDefaultValues -join ' ,')"
-                            if ($Truncate -and !$NoTransaction) {
+                            if ($Truncate -and !$NoTransaction -and $PSCmdlet.ShouldProcess($instance, "Performing Static column value UPDATE TABLE [$schema].[$table] on $Database")) {
                                 Write-Message -Level Verbose -Message "About to run update statement: $sql"
                                 $sqlcmd = New-Object System.Data.SqlClient.SqlCommand($sql, $sqlconn, $transaction)
                                 $sqlcmd.CommandTimeout = 0

--- a/functions/Import-DbaCsv.ps1
+++ b/functions/Import-DbaCsv.ps1
@@ -668,14 +668,14 @@ function Import-DbaCsv {
                             #if we're truncating and wrapped in a transaction, otherwise provide potentially unsafe sql as output to be used by caller with discretion
                             $UpdateStatementForStaticColumns = "UPDATE [$schema].[$table] SET $($sqlColDefaultValues -join ' ,')"
                             if ($Truncate -and !$NoTransaction -and $PSCmdlet.ShouldProcess($instance, "Performing Static column value UPDATE TABLE [$schema].[$table] on $Database")) {
-                                Write-Message -Level Verbose -Message "About to run update statement: $sql"
-                                $sqlcmd = New-Object System.Data.SqlClient.SqlCommand($sql, $sqlconn, $transaction)
+                                Write-Message -Level Verbose -Message "About to run update statement: $UpdateStatementForStaticColumns"
+                                $sqlcmd = New-Object System.Data.SqlClient.SqlCommand($UpdateStatementForStaticColumns, $sqlconn, $transaction)
                                 $sqlcmd.CommandTimeout = 0
                                 try {
                                     $null = $sqlcmd.ExecuteNonQuery()
                                 } catch {
                                     $errormessage = $_.Exception.Message.ToString()
-                                    Stop-Function -Continue -Message "Failed to execute $sql. `nDid you specify the proper delimiter? `n$errormessage"
+                                    Stop-Function -Continue -Message "Failed to execute $UpdateStatementForStaticColumns. `nDid you specify the proper delimiter? `n$errormessage"
                                 }
                             }
                         }


### PR DESCRIPTION
## Type of Change
<!-- What type of change does your code introduce -->
 - [ ] Bug fix (non-breaking change, fixes #<!--issue number--> )
 - [X] New feature (non-breaking change, adds functionality, fixes #<!--issue number--> )
 - [ ] Breaking change (effects multiple commands or functionality, fixes #<!--issue number--> )
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1`)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] If new file reference added for test, has is been added to github.com/sqlcollaborative/appveyor-lab ?
 - [ ] Unit test is included
 - [ ] Documentation
 - [ ] Build system

### Purpose
Provide the end user the update statement that we would have executed if the import were wrapped in a transaction and the table truncated prior to insertion

### Approach
It writes the update statement if you've provided a `StaticColumnMap` and only execs it if `-NoTransaction` wasn't provided and `-Truncate` was used 